### PR TITLE
Dependabot `postcss`

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
         "react-scripts": "5.0.1",
         "typescript": "^5.8.2"
     },
+    "resolutions": {
+        "react-scripts/**/postcss": "^8.4.31"
+    },
     "devDependencies": {
         "@babel/eslint-parser": "^7.26.8",
         "@babel/preset-react": "^7.26.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7345,11 +7345,6 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==
 
-picocolors@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-0.2.1.tgz#570670f793646851d1ba135996962abad587859f"
-  integrity sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==
-
 picocolors@^1.0.0, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
@@ -7937,15 +7932,7 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.1.0, postcss-value-parser@^
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^7.0.35:
-  version "7.0.39"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.39.tgz#9624375d965630e2e1f2c02a935c82a59cb48309"
-  integrity sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==
-  dependencies:
-    picocolors "^0.2.1"
-    source-map "^0.6.1"
-
-postcss@^8.3.5, postcss@^8.4.33, postcss@^8.4.4, postcss@^8.4.47:
+postcss@^7.0.35, postcss@^8.3.5, postcss@^8.4.31, postcss@^8.4.33, postcss@^8.4.4, postcss@^8.4.47:
   version "8.5.3"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.3.tgz#1463b6f1c7fb16fe258736cba29a2de35237eafb"
   integrity sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==


### PR DESCRIPTION
https://github.com/rblakeman/portfolio-react/security/dependabot/53

```
PostCSS line return parsing error #53
 Open Opened 2 years ago on postcss (npm) · [yarn.lock](https://github.com/rblakeman/portfolio-react/blob/-/yarn.lock)
Dependabot cannot update postcss to a non-vulnerable version
The latest possible version that can be installed is 7.0.39 because of the following conflicting dependencies:

react-scripts@5.0.1 requires postcss@^8.4.33 via a transitive dependency on css-loader@6.11.0
react-scripts@5.0.1 requires postcss@^7.0.35 via a transitive dependency on resolve-url-loader@4.0.0
react-scripts@5.0.1 requires postcss@^8.4.47 via a transitive dependency on tailwindcss@3.4.17
The earliest fixed version is 8.4.31.

Transitive dependency postcss 7.0.39 is introduced via
react-scripts 5.0.1  ...  postcss 7.0.39
Package
Affected versions
Patched version
postcss
(npm)
< 8.4.31
8.4.31
An issue was discovered in PostCSS before 8.4.31. It affects linters using PostCSS to parse external Cascading Style Sheets (CSS). There may be \r discrepancies, as demonstrated by @font-face{ font:(\r/*);} in a rule.

This vulnerability affects linters using PostCSS to parse external untrusted CSS. An attacker can prepare CSS in such a way that it will contains parts parsed by PostCSS as a CSS comment. After processing by PostCSS, it will be included in the PostCSS output in CSS nodes (rules, properties) despite being originally included in a comment.

@[dependabot](https://docs.github.com/code-security/dependabot/dependabot-alerts) dependabot bot opened this 2 years ago
```